### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "45 0 * * 5" # Every Friday at 00:45 UTC
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/NickBonet/weekly_meal_planner_bot/security/code-scanning/3](https://github.com/NickBonet/weekly_meal_planner_bot/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow to explicitly define the permissions required. Based on the workflow's functionality:
- The `contents: read` permission is needed to check out the repository code.
- The `packages: write` permission is required to log in to the GitHub Container Registry and push Docker images.

This ensures the workflow has only the permissions it needs and no unnecessary write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
