### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -9,6 +9,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   gitleaks:
     name: gitleaks


### PR DESCRIPTION
Potential fix for [https://github.com/NickBonet/weekly_meal_planner_bot/security/code-scanning/2](https://github.com/NickBonet/weekly_meal_planner_bot/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the Gitleaks action only needs to read the repository's contents to perform its scan, we will set `contents: read` as the permission. This ensures that the workflow adheres to the principle of least privilege.

The `permissions` block will be added at the workflow level (root) to apply to all jobs in the workflow. This is sufficient because the workflow contains only one job (`gitleaks`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
